### PR TITLE
Add iota and iota-description lang

### DIFF
--- a/src/main/resources/assets/hexcellular/lang/en_us.json
+++ b/src/main/resources/assets/hexcellular/lang/en_us.json
@@ -7,6 +7,9 @@
 	"hexcasting.action.book.hexcellular:set_property": "Schrödinger's Gambit",
 	"hexcasting.action.book.hexcellular:observe_property": "Observation Purif.",
 
+	"hexcasting.iota.hexcellular:property": "Property",
+	"hexcasting.iota.hexcellular:property.desc": "a property iota",
+	
 	"hexcasting.mishap.invalid_value.class.property": "a property iota",
 	"hexcasting.mishap.invalid_value.writeable_prop": "a writeable property iota",
 


### PR DESCRIPTION
Going forward, addons should implement these lang keys for their iotas, for use in MishapInvalidIota.